### PR TITLE
Makes list disappear once you're on a detail page

### DIFF
--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -2,19 +2,18 @@ import React, { Component } from 'react';
 
 class AnimeDetails extends Component {
     state = {
-        animeDetails: {},
-        url: this.props.location
+        animeDetails: this.props.location.state.anime
     }
 
-    // async componentDidMount() {
-    //     const animeDetails = await 
-    // }
-
     render() {
-        console.log('this.props.location: ', this.state.url);
+        console.log('this.state.animeDetails is: ', this.state.animeDetails);
         return (
             <div>
                 <h1>anime details</h1>
+                <h1>{this.state.animeDetails.title}</h1>
+                <p>{this.state.animeDetails.synopsis}</p>
+
+                
                 {/* <h1>{this.props.animes.results.title}</h1>
                 <img src={this.props.animes.results.image_url} alt="" />
                 <p><b>Type:</b>{this.props.animes.results.type}</p>

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -3,17 +3,19 @@ import React, { Component } from 'react';
 class AnimeDetails extends Component {
     state = {
         animeDetails: {},
-        // url: 
+        url: this.props.location
     }
 
-    async componentDidMount() {
-        const animeDetails = await 
-    }
+    // async componentDidMount() {
+    //     const animeDetails = await 
+    // }
 
     render() {
+        console.log('this.props.location: ', this.state.url);
         return (
             <div>
-                <h1>{this.props.animes.results.title}</h1>
+                <h1>anime details</h1>
+                {/* <h1>{this.props.animes.results.title}</h1>
                 <img src={this.props.animes.results.image_url} alt="" />
                 <p><b>Type:</b>{this.props.animes.results.type}</p>
                 {this.props.animes.results.type === "TV"
@@ -25,7 +27,7 @@ class AnimeDetails extends Component {
                 }
                 <p><b>Rated: </b>{this.props.animes.results.rated}</p>
                 <p><b>Synopsis: </b>{this.props.animes.results.synopsis}</p>
-                <a href={this.props.animes.results.url}>More Info</a>
+                <a href={this.props.animes.results.url}>More Info</a> */}
             </div>
         )
     }

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 
 class AnimeDetails extends Component {
     state = {
-        AnimeDetails: {},
-        url: 
+        animeDetails: {},
+        // url: 
     }
 
     render() {

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -12,8 +12,9 @@ class AnimeDetails extends Component {
                 <h1>anime details</h1>
                 <h1>{this.state.animeDetails.title}</h1>
                 <p>{this.state.animeDetails.synopsis}</p>
+                <a href="/">Return</a>
 
-                
+
                 {/* <h1>{this.props.animes.results.title}</h1>
                 <img src={this.props.animes.results.image_url} alt="" />
                 <p><b>Type:</b>{this.props.animes.results.type}</p>

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -10,7 +10,6 @@ class AnimeDetails extends Component {
         const { animeDetails } = this.state
         return (
             <div>
-                <h1>anime details</h1>
                 <h1>{animeDetails.title}</h1>
                 <p>{animeDetails.synopsis}</p>
                 <a href="/">Return</a>

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -1,6 +1,11 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
 
 class AnimeDetails extends Component {
+    state = {
+        AnimeDetails: {},
+        url: 
+    }
+
     render() {
         return (
             <div>

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -7,11 +7,12 @@ class AnimeDetails extends Component {
 
     render() {
         console.log('this.state.animeDetails is: ', this.state.animeDetails);
+        const { animeDetails } = this.state
         return (
             <div>
                 <h1>anime details</h1>
-                <h1>{this.state.animeDetails.title}</h1>
-                <p>{this.state.animeDetails.synopsis}</p>
+                <h1>{animeDetails.title}</h1>
+                <p>{animeDetails.synopsis}</p>
                 <a href="/">Return</a>
 
 

--- a/src/pages/AnimeDetails/AnimeDetails.js
+++ b/src/pages/AnimeDetails/AnimeDetails.js
@@ -6,6 +6,10 @@ class AnimeDetails extends Component {
         // url: 
     }
 
+    async componentDidMount() {
+        const animeDetails = await 
+    }
+
     render() {
         return (
             <div>

--- a/src/pages/AnimeResults/AnimeResults.js
+++ b/src/pages/AnimeResults/AnimeResults.js
@@ -8,7 +8,12 @@ class AnimeResults extends Component {
             <>
                 {this.props.animes.map((anime, idx) => (
                     <div className='anime' key={idx} >
-                        <Link to='anime' state={{ anime }}>
+                        <Link 
+                            to={{
+                                pathname: `/anime`,
+                                state: { anime }
+                            }}
+                        >
                             <h2>{anime.title}</h2>
                             <img src={anime.image_url} alt="" />
                         </Link>

--- a/src/pages/App/App.jsx
+++ b/src/pages/App/App.jsx
@@ -43,7 +43,9 @@ class App extends Component {
 	}
 
 
+
 	handleSubmit = (e) => {
+		console.log(this.props);
 		e.preventDefault();
 		this.setState({
 			searchURL: this.state.baseURL + this.state.query + this.state.animeTitle + this.state.limit
@@ -56,6 +58,11 @@ class App extends Component {
 				}))
 				.catch(err => console.log(err))
 		})
+		if (this.props.history.location.pathname === '/') {
+			console.log('home');
+		} else {
+			this.props.history.push('/')
+		}
 	}
 
 	render() {
@@ -63,33 +70,9 @@ class App extends Component {
 		return (
 			<>
 				<NavBar user={user} handleLogout={this.handleLogout} />
-				<Route exact path='/'>
-					<Landing user={user} />
-				</Route>
-				<Route exact path='/signup'>
-					<Signup history={this.props.history} handleSignupOrLogin={this.handleSignupOrLogin} />
-				</Route>
-				<Route exact path='/login'>
-					<Login handleSignupOrLogin={this.handleSignupOrLogin} history={this.props.history} />
-				</Route>
-				<Route
-					exact path="/users"
-					render={() =>
-						user ? <Users /> : <Redirect to='/login' />
-					}
-				/>
-				<Route
-					exact path='/anime'
-					render={({ location }) =>
-						<AnimeDetails
-							location={location}
-						/>
-					}
-				/>
-
-
 				<form onSubmit={this.handleSubmit}>
 					<label htmlFor="animeTitle">Title</label>
+					{/* <Redirect to="anime-results"/> */}
 					<input
 						id="animeTitle"
 						type="text"
@@ -98,8 +81,40 @@ class App extends Component {
 					/>
 					<input type="submit" value="Search" />
 				</form>
+				
+				<Route exact path='/'>
+					<Landing user={user} animes={this.state.animes} />
+				</Route>
 
-				{(this.state.animes) ? <AnimeResults animes={this.state.animes.results} /> : ''}
+				<Route exact path='/signup'>
+					<Signup history={this.props.history} handleSignupOrLogin={this.handleSignupOrLogin} />
+				</Route>
+
+				<Route exact path='/login'>
+					<Login handleSignupOrLogin={this.handleSignupOrLogin} history={this.props.history} />
+				</Route>
+
+				<Route
+					exact path="/users"
+					render={() =>
+						user ? <Users /> : <Redirect to='/login' />
+					}
+				/>
+				<Route
+					exact path='/anime-results'
+					render={() =>
+						<AnimeResults animes={this.state.animes}/>
+					}
+				/>
+
+				<Route
+					exact path='/anime'
+					render={({ location }) =>
+						<AnimeDetails
+							location={location}
+						/>
+					}
+				/>	
 			</>
 		)
 	}

--- a/src/pages/App/App.jsx
+++ b/src/pages/App/App.jsx
@@ -98,7 +98,6 @@ class App extends Component {
 					/>
 					<input type="submit" value="Search" />
 				</form>
-				<a href={this.state.searchURL}>{this.state.searchURL}</a>
 
 				{(this.state.animes) ? <AnimeResults animes={this.state.animes.results} /> : ''}
 			</>

--- a/src/pages/Landing/Landing.jsx
+++ b/src/pages/Landing/Landing.jsx
@@ -1,11 +1,11 @@
 import styles from './Landing.module.css'
+import AnimeResults from '../AnimeResults/AnimeResults'
 
-const Landing = ({user}) => {
+const Landing = (props) => {
+  console.log(props);
   return (
     <main className={styles.container}>
-      <h1>
-        hello, {user ? user.name : "friend"}
-      </h1>
+      {(props.animes) ? <AnimeResults animes={props.animes.results} /> : ''}
     </main>
   )
 }

--- a/src/services/api-calls.js
+++ b/src/services/api-calls.js
@@ -1,0 +1,2 @@
+const baseURL = 'https://api.jikan.moe/v3/search/anime?';
+const query = 'q=';

--- a/src/services/api-calls.js
+++ b/src/services/api-calls.js
@@ -1,2 +1,6 @@
 const baseURL = 'https://api.jikan.moe/v3/search/anime?';
 const query = 'q=';
+
+export function getDetails(apiUrl) {
+    return fetch(`${baseURL}${query}`)
+}


### PR DESCRIPTION
- adds state to AnimeDetails
- tweaks path for Link
- adds baseURL and query to api-calls
- adds location to AnimeDetails
- adds synopsis to details page
- adds a back to search button
- destructures animeDetails
- fixes issue: the anime list used to display under the detail view and wouldn't go away
